### PR TITLE
Persister

### DIFF
--- a/scrapy/extensions/spiderstate.py
+++ b/scrapy/extensions/spiderstate.py
@@ -1,40 +1,52 @@
 import os
 import pickle
+import warnings
 
 from scrapy import signals
 from scrapy.exceptions import NotConfigured
-from scrapy.utils.job import job_dir
+from scrapy.utils.deprecate import ScrapyDeprecationWarning
+from scrapy.utils.job import persister_from_settings, DiskPersister
 
 
 class SpiderState:
     """Store and load spider state during a scraping job"""
 
-    def __init__(self, jobdir=None):
-        self.jobdir = jobdir
+    def __init__(self, jobdir=None, persister=None):
+        if jobdir is not None:
+            warnings.warn("Setting the 'jobdir' argument is deprecated. Please create "
+                          "a scrapy.utils.job.DiskPersister object and set the "
+                          "'persister' argument instead.",
+                          ScrapyDeprecationWarning,
+                          stacklevel=2)
+            self.persister = DiskPersister(jobdir)
+        else:
+            self.persister = persister
 
     @classmethod
     def from_crawler(cls, crawler):
-        jobdir = job_dir(crawler.settings)
-        if not jobdir:
+        persister = persister_from_settings(crawler.settings)
+        if not persister:
             raise NotConfigured
 
-        obj = cls(jobdir)
+        obj = cls(persister=persister)
         crawler.signals.connect(obj.spider_closed, signal=signals.spider_closed)
         crawler.signals.connect(obj.spider_opened, signal=signals.spider_opened)
         return obj
 
     def spider_closed(self, spider):
-        if self.jobdir:
-            with open(self.statefn, 'wb') as f:
-                pickle.dump(spider.state, f, protocol=4)
+        if self.persister:
+            self.persister.set('spider.state', pickle.dumps(spider.state, protocol=4))
 
     def spider_opened(self, spider):
-        if self.jobdir and os.path.exists(self.statefn):
-            with open(self.statefn, 'rb') as f:
-                spider.state = pickle.load(f)
+        if self.persister and self.persister.exists('spider.state'):
+            spider.state = pickle.loads(self.persister.get('spider.state'))
         else:
             spider.state = {}
 
     @property
     def statefn(self):
-        return os.path.join(self.jobdir, 'spider.state')
+        warnings.warn("Accessing the 'statefn' property is deprecated. Please use "
+                      "the 'persister' argument instead.",
+                      ScrapyDeprecationWarning,
+                      stacklevel=2)
+        return os.path.join(self.persister.jobdir, 'spider.state')

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -192,6 +192,8 @@ ITEM_PROCESSOR = 'scrapy.pipelines.ItemPipelineManager'
 ITEM_PIPELINES = {}
 ITEM_PIPELINES_BASE = {}
 
+JOB_PERSISTER = 'scrapy.utils.job.DiskPersister'
+
 LOG_ENABLED = True
 LOG_ENCODING = 'utf-8'
 LOG_FORMATTER = 'scrapy.logformatter.LogFormatter'

--- a/scrapy/utils/job.py
+++ b/scrapy/utils/job.py
@@ -1,8 +1,99 @@
 import os
+from abc import ABC, abstractmethod
+
+from scrapy.exceptions import NotConfigured
+from scrapy.utils.misc import create_instance, load_object
 
 
 def job_dir(settings):
-    path = settings['JOBDIR']
-    if path and not os.path.exists(path):
-        os.makedirs(path)
-    return path
+    return settings['JOBDIR']
+
+
+class Persister(ABC):
+
+    @abstractmethod
+    def get(self, key, fallback=None):
+        pass
+
+    @abstractmethod
+    def set(self, key, value):
+        pass
+
+    @abstractmethod
+    def exists(self, key):
+        pass
+
+    @abstractmethod
+    def append(self, key, value):
+        pass
+
+    @abstractmethod
+    def remove(self, key):
+        pass
+
+    @abstractmethod
+    def close(self, key):
+        pass
+
+    def _key_path(self, key):
+        return os.path.join(self.jobdir, key)
+
+
+class DiskPersister(Persister):
+
+    @classmethod
+    def from_settings(cls, settings):
+        jobdir = job_dir(settings)
+        if not jobdir:
+            raise NotConfigured
+        return cls(jobdir=jobdir)
+
+    def __init__(self, jobdir):
+        self.jobdir = jobdir
+        self._files = {}
+
+    def get(self, key, fallback=None):
+        if self.exists(key):
+            with open(self._key_path(key), 'rb') as f:
+                return f.read()
+        else:
+            return fallback
+
+    def set(self, key, value):
+        os.makedirs(os.path.dirname(self._key_path(key)), exist_ok=True)
+        with open(self._key_path(key), 'wb') as f:
+            f.write(value)
+
+    def exists(self, key):
+        return os.path.exists(self._key_path(key))
+
+    def append(self, key, value):
+        if key not in self._files:
+            os.makedirs(os.path.dirname(self._key_path(key)), exist_ok=True)
+            self._files[key] = open(self._key_path(key), 'ab+')
+
+        self._files[key].write(value)
+
+    def remove(self, key):
+        os.unlink(self._key_path(key))
+        try:
+            # Remove the parent directory if it's empty.
+            os.rmdir(os.path.dirname(self._key_path(key)))
+        except (FileNotFoundError, OSError):
+            pass
+
+    def close(self, key):
+        if key in self._files:
+            self._files[key].close()
+            del self._files[key]
+
+
+def persister_from_settings(settings):
+    persister_cls = settings['JOB_PERSISTER']
+    if not persister_cls:
+        return None
+
+    try:
+        return create_instance(load_object(persister_cls), settings, crawler=None)
+    except NotConfigured:
+        return None

--- a/tests/test_spiderstate.py
+++ b/tests/test_spiderstate.py
@@ -7,6 +7,7 @@ from scrapy.extensions.spiderstate import SpiderState
 from scrapy.spiders import Spider
 from scrapy.exceptions import NotConfigured
 from scrapy.utils.test import get_crawler
+from scrapy.utils.job import DiskPersister
 
 
 class SpiderStateTest(unittest.TestCase):
@@ -18,14 +19,14 @@ class SpiderStateTest(unittest.TestCase):
             spider = Spider(name='default')
             dt = datetime.now()
 
-            ss = SpiderState(jobdir)
+            ss = SpiderState(persister=DiskPersister(jobdir))
             ss.spider_opened(spider)
             spider.state['one'] = 1
             spider.state['dt'] = dt
             ss.spider_closed(spider)
 
             spider2 = Spider(name='default')
-            ss2 = SpiderState(jobdir)
+            ss2 = SpiderState(persister=DiskPersister(jobdir))
             ss2.spider_opened(spider2)
             self.assertEqual(spider.state, {'one': 1, 'dt': dt})
             ss2.spider_closed(spider2)


### PR DESCRIPTION
This PR ~builds on the previous work in the redis branch (PR #1) and~ introduces the concept of a *Persister* which abstracts away the current `JOBDIR` storage mechanism. The basic idea is that instead of checking if the `JOBDIR` setting is configured and using it as a directory where arbitrary data can be read from and written to, a Persister should be used instead. A Persister offers a common interface to its users so they don‘t have to worry how the data is persisted.

Currently there ~are two implementations~ is only one implementation: A disk-based persister (`scrapy.utils.job.DiskPersister`) which basically mimics the current behavior in a backwards-compatible way. ~The second persister is the `scrapy.utils.job.RedisPersister` which uses Redis to persist data.~ The concrete implementaton of the persister can be configured via the commonly used dependency injection mechanism: The `JOB_PERSISTER` setting expects a fully-qualified name of a class that implements the persister interface.